### PR TITLE
issues/51 - Fix test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint \"src/**/*.ts?(x)\" --ext .js,.jsx,.ts,.tsx",
     "prettier:check": "prettier --check .",
     "prettier:format": "prettier --write .",
-    "test": "jest --config --runInBand jest.config.js",
+    "test": "jest --config jest.config.js --runInBand",
     "tsc:check": "tsc --noEmit",
     "start": "nodemon",
     "start:prod": "cross-env NODE_ENV=production node dist/server/server.js"


### PR DESCRIPTION
When I ran command "npm test", I received error:

Pattern: jest.config.js - 0 matches
npm ERR! Test failed.
The current test script is described as

"test": "jest --config --runInBand jest.config.js"
To fix it, I changed the script to:

"test": "jest --config jest.config.js --runInBand"